### PR TITLE
Fix release reference for tituspijean-auth-ssowat config

### DIFF
--- a/config/various-project.php
+++ b/config/various-project.php
@@ -317,8 +317,9 @@ return [
 		'branch' => 'https://raw.githubusercontent.com/tituspijean/flarum-ext-auth-ldap/master/locale/en.yml',
 	],
 	'tituspijean-auth-ssowat' => [
-		'tag' => 'https://raw.githubusercontent.com/tituspijean/flarum-ext-auth-ssowat/0.6/locale/en.yml',
+		'tag:v0.1.' => 'https://raw.githubusercontent.com/tituspijean/flarum-ext-auth-ssowat/v0.1.0-beta.10-2/locale/en.yml',
 		'branch' => 'https://raw.githubusercontent.com/tituspijean/flarum-ext-auth-ssowat/master/locale/en.yml',
+		'tag' => 'https://raw.githubusercontent.com/tituspijean/flarum-ext-auth-ssowat/0.6/locale/en.yml',
 	],
 	'tpokorra-post-notification' => [
 		'tag' => 'https://raw.githubusercontent.com/tpokorra/flarum-ext-post-notification/0.3.6/resources/locale/en.yml',


### PR DESCRIPTION
This extensions does not follow semver: https://github.com/tituspijean/flarum-ext-auth-ssowat/releases

![1c06fc8c](https://user-images.githubusercontent.com/5972388/73390616-bd9f7500-42d6-11ea-8224-8ae9f264775f.png)

refs #243