### PR TITLE
Add support for premium extensions

### DIFF
--- a/config/premium-extensions.php
+++ b/config/premium-extensions.php
@@ -12,4 +12,36 @@
 declare(strict_types=1);
 
 return [
+	'datitisev-backup' => [
+		'name' => 'Backup',
+		'packageName' => 'datitisev/flarum-backup',
+	],
+	'datitisev-maintenance' => [
+		'name' => 'Maintenance Mode',
+		'packageName' => 'datitisev/flarum-maintenance',
+	],
+	'kilowhat-custom-paths' => [
+		'name' => 'Custom Paths',
+		'packageName' => 'kilowhat/flarum-ext-custom-paths',
+	],
+	'kilowhat-formulaire' => [
+		'name' => 'Formulaire',
+		'packageName' => 'kilowhat/flarum-ext-formulaire',
+	],
+	'kilowhat-wordpress' => [
+		'name' => 'Wordpress Integration',
+		'packageName' => 'kilowhat/flarum-ext-wordpress',
+	],
+	'kyrne-websocket' => [
+		'name' => 'Websocket',
+		'packageName' => 'kyrne/websocket',
+	],
+	'reflar-recache' => [
+		'name' => 'ReFlar ReCache',
+		'packageName' => 'reflar/recache',
+	],
+	'reflar-webhooks-pro' => [
+		'name' => 'ReFlar Webhooks PRO',
+		'packageName' => 'reflar/webhooks-pro',
+	],
 ];

--- a/config/various-project.php
+++ b/config/various-project.php
@@ -88,8 +88,14 @@ return [
 	'clarkwinkelmann-who-read' => [
 		'tag' => 'https://raw.githubusercontent.com/clarkwinkelmann/flarum-ext-who-read/1.2.0/resources/locale/en.yml',
 	],
+	'datitisev-backup' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/datitisev-backup.yml',
+	],
 	'datitisev-dashboard' => [
 		'tag' => 'https://raw.githubusercontent.com/datitisev/flarum-ext-dashboard/v0.1.0-beta.8.2/resources/locale/en.yml',
+	],
+	'datitisev-maintenance' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/datitisev-maintenance.yml',
 	],
 	'dem13n-auth-mailru' => [
 		'tag' => 'https://raw.githubusercontent.com/Dem13n/auth-mailru/0.1.0/resources/locale/en.yml',
@@ -169,8 +175,17 @@ return [
 	'kilowhat-affiliation-links' => [
 		'tag' => 'https://raw.githubusercontent.com/kilowhat/flarum-ext-affiliation-links/0.2.0/resources/locale/en.yml',
 	],
+	'kilowhat-custom-paths' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/kilowhat-custom-paths.yml',
+	],
+	'kilowhat-formulaire' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/kilowhat-formulaire.yml',
+	],
 	'kilowhat-mailing' => [
 		'tag' => 'https://raw.githubusercontent.com/kilowhat/flarum-ext-mailing/0.2.3/resources/locale/en.yml',
+	],
+	'kilowhat-wordpress' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/kilowhat-wordpress.yml',
 	],
 	'kvothe-keyboard-shortcuts' => [
 		'tag' => 'https://raw.githubusercontent.com/oaklinq/flarum-ext-keyboard-shortcuts/v0.1.0/resources/locale/en.yml',
@@ -186,6 +201,9 @@ return [
 	],
 	'kvothe-spoiler-bbcode' => [
 		'tag' => 'https://raw.githubusercontent.com/oaklinq/flarum-ext-spoiler-bbcode/0.1.0/resources/locale/en.yml',
+	],
+	'kyrne-websocket' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/kyrne-websocket.yml',
 	],
 	'maicol07-sso' => [
 		'tag' => 'https://raw.githubusercontent.com/maicol07/flarum-ext-sso/1.6/locale/en.yml',
@@ -244,11 +262,17 @@ return [
 	'reflar-level-ranks' => [
 		'tag' => 'https://raw.githubusercontent.com/ReFlar/level-ranks/1.2.2/resources/locale/en.yml',
 	],
+	'reflar-recache' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/reflar-recache.yml',
+	],
 	'reflar-twofactor' => [
 		'tag' => 'https://raw.githubusercontent.com/ReFlar/twofactor/0.1.3/resources/locale/en.yml',
 	],
 	'reflar-webhooks' => [
 		'tag' => 'https://raw.githubusercontent.com/ReFlar/webhooks/0.2.3/resources/locale/en.yml',
+	],
+	'reflar-webhooks-pro' => [
+		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/reflar-webhooks-pro.yml',
 	],
 	'saleksin-auth-google' => [
 		'tag' => 'https://raw.githubusercontent.com/saleksin/flarum-auth-google/v0.1.0-beta.8.0.3/locale/en.yml',


### PR DESCRIPTION
Adds support for:

* [`datitisev-backup`](https://extiverse.com/extension/datitisev/flarum-backup),
* [`datitisev-maintenance`](https://extiverse.com/extension/datitisev/flarum-maintenance),
* [`kilowhat-custom-paths`](https://extiverse.com/extension/kilowhat/flarum-ext-custom-paths),
* [`kilowhat-formulaire`](https://extiverse.com/extension/kilowhat/flarum-ext-formulaire),
* [`kilowhat-wordpress`](https://extiverse.com/extension/kilowhat/flarum-ext-wordpress),
* [`kyrne-websocket`](https://extiverse.com/extension/kyrne/websocket),
* [`reflar-recache`](https://extiverse.com/extension/reflar/recache),
* [`reflar-webhooks-pro`](https://extiverse.com/extension/reflar/webhooks-pro).

https://extiverse.com/?filter[is][]=premium

fix https://github.com/rob006-software/flarum-translations/issues/306