### PR TITLE
Add nearata/flarum-ext-tags-color-generator

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -503,6 +503,9 @@ return [
 	'nearata-minecraft-avatars' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-minecraft-avatars/v1.1.1/resources/locale/en.yml',
 	],
+	'nearata-tags-color-generator' => [
+		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-tags-color-generator/v1.1.0/resources/locale/en.yml',
+	],
 	'nikovonlas-auth-vk' => [
 		'tag' => 'https://raw.githubusercontent.com/NikoVonLas/flarum-ext-auth-vk/v0.1.0-beta.7/locale/en.yml',
 	],


### PR DESCRIPTION
## [nearata/flarum-ext-tags-color-generator at Packagist](https://packagist.org/packages/nearata/flarum-ext-tags-color-generator)

![License](https://poser.pugx.org/nearata/flarum-ext-tags-color-generator/license)

![Latest Stable Version](https://poser.pugx.org/nearata/flarum-ext-tags-color-generator/v/stable) ![Latest Unstable Version](https://poser.pugx.org/nearata/flarum-ext-tags-color-generator/v/unstable)
[![Total Downloads](https://poser.pugx.org/nearata/flarum-ext-tags-color-generator/downloads) ![Monthly Downloads](https://poser.pugx.org/nearata/flarum-ext-tags-color-generator/d/monthly) ![Daily Downloads](https://poser.pugx.org/nearata/flarum-ext-tags-color-generator/d/daily)](https://packagist.org/packages/nearata/flarum-ext-tags-color-generator/stats)

## [Nearata/flarum-ext-tags-color-generator at GitHub](https://github.com/Nearata/flarum-ext-tags-color-generator)

![GitHub license](https://img.shields.io/github/license/Nearata/flarum-ext-tags-color-generator)

[![GitHub last tag](https://img.shields.io/github/tag-date/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/network) [![GitHub issues](https://img.shields.io/github/issues/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Nearata/flarum-ext-tags-color-generator)](https://github.com/Nearata/flarum-ext-tags-color-generator/graphs/contributors)

## Other

https://extiverse.com/extension/nearata/flarum-ext-tags-color-generator

https://discuss.flarum.org/d/24644-tags-color-generator

