### PR TITLE
Add nearata/flarum-ext-is-online

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -497,6 +497,9 @@ return [
 	'nearata-embed-video' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-embed-video/v1.0.0/resources/locale/en.yml',
 	],
+	'nearata-is-online' => [
+		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-is-online/v1.0.1/resources/locale/en.yml',
+	],
 	'nearata-minecraft-avatars' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-minecraft-avatars/v1.1.1/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [nearata/flarum-ext-is-online at Packagist](https://packagist.org/packages/nearata/flarum-ext-is-online)

![License](https://poser.pugx.org/nearata/flarum-ext-is-online/license)

![Latest Stable Version](https://poser.pugx.org/nearata/flarum-ext-is-online/v/stable) ![Latest Unstable Version](https://poser.pugx.org/nearata/flarum-ext-is-online/v/unstable)
[![Total Downloads](https://poser.pugx.org/nearata/flarum-ext-is-online/downloads) ![Monthly Downloads](https://poser.pugx.org/nearata/flarum-ext-is-online/d/monthly) ![Daily Downloads](https://poser.pugx.org/nearata/flarum-ext-is-online/d/daily)](https://packagist.org/packages/nearata/flarum-ext-is-online/stats)

## [Nearata/flarum-ext-is-online at GitHub](https://github.com/Nearata/flarum-ext-is-online)

![GitHub license](https://img.shields.io/github/license/Nearata/flarum-ext-is-online)

[![GitHub last tag](https://img.shields.io/github/tag-date/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/network) [![GitHub issues](https://img.shields.io/github/issues/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Nearata/flarum-ext-is-online)](https://github.com/Nearata/flarum-ext-is-online/graphs/contributors)

## Other

https://extiverse.com/extension/nearata/flarum-ext-is-online

https://discuss.flarum.org/d/24654-is-online