### PR TITLE
Add alongwy/flarum-elasticsearch

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -24,6 +24,9 @@ return [
 		'https://raw.githubusercontent.com/flarum/lang-english/master/locale/validation.yml',
 	],
 	/* extensions list begin */
+	'alongwy-elasticsearch' => [
+		'tag' => 'https://raw.githubusercontent.com/AlongWY/flarum-elasticsearch/v0.0.1/resources/locale/en.yml',
+	],
 	'amaurycarrade-syndication' => [
 		'tag' => 'https://raw.githubusercontent.com/AmauryCarrade/flarum-ext-syndication/v0.3.1/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [alongwy/flarum-elasticsearch at Packagist](https://packagist.org/packages/alongwy/flarum-elasticsearch)
Is the badges here saved by dragging here after they generated on https://shields.io/?

## [alongwy/flarum-elasticsearch at GitHub](https://github.com/AlongWY/flarum-elasticsearch)

## Other
https://extiverse.com/extension/alongwy/flarum-elasticsearch