### PR TITLE
Exclude `the-turk` extensions from TR translations

### DIFF
--- a/config/languages.php
+++ b/config/languages.php
@@ -16,6 +16,19 @@ use function rob006\flarum\translations\helpers\getComponents;
 return [
 	'ja' => getComponents(),
 	'pl' => getComponents(),
-	'tr' => getComponents(),
+	'tr' => getComponents([
+		// the-turk extensions has TR translations included
+		// @see https://github.com/rob006-software/flarum-translations/issues/425
+		'!the-turk-diff',
+		'!the-turk-edit-notifications',
+		'!the-turk-extended-appearance',
+		'!the-turk-fancybox',
+		'!the-turk-mathren',
+		'!the-turk-password-strength',
+		'!the-turk-quiet-edits',
+		'!the-turk-regrole',
+		'!the-turk-stargazing-theme',
+		'!the-turk-welcome-widgets',
+	]),
 	'zh_Hans' => getComponents(),
 ];


### PR DESCRIPTION
fix https://github.com/rob006-software/flarum-translations/issues/425