### PR TITLE
Add nearata/flarum-ext-auth-minecraft

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -534,6 +534,9 @@ return [
 	'miniflar-sidenav-download-button' => [
 		'tag' => 'https://raw.githubusercontent.com/miniflar/sidenav-download-button/0.2.1/resources/locale/en.yml',
 	],
+	'nearata-auth-minecraft' => [
+		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-auth-minecraft/v1.0.0/resources/locale/en.yml',
+	],
 	'nearata-cakeday' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-cakeday/v1.3.0/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [nearata/flarum-ext-auth-minecraft at Packagist](https://packagist.org/packages/nearata/flarum-ext-auth-minecraft)

![License](https://poser.pugx.org/nearata/flarum-ext-auth-minecraft/license)

![Latest Stable Version](https://poser.pugx.org/nearata/flarum-ext-auth-minecraft/v/stable) ![Latest Unstable Version](https://poser.pugx.org/nearata/flarum-ext-auth-minecraft/v/unstable)
[![Total Downloads](https://poser.pugx.org/nearata/flarum-ext-auth-minecraft/downloads) ![Monthly Downloads](https://poser.pugx.org/nearata/flarum-ext-auth-minecraft/d/monthly) ![Daily Downloads](https://poser.pugx.org/nearata/flarum-ext-auth-minecraft/d/daily)](https://packagist.org/packages/nearata/flarum-ext-auth-minecraft/stats)

## [Nearata/flarum-ext-auth-minecraft at GitHub](https://github.com/Nearata/flarum-ext-auth-minecraft)

![GitHub license](https://img.shields.io/github/license/Nearata/flarum-ext-auth-minecraft)

[![GitHub last tag](https://img.shields.io/github/tag-date/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/network) [![GitHub issues](https://img.shields.io/github/issues/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Nearata/flarum-ext-auth-minecraft)](https://github.com/Nearata/flarum-ext-auth-minecraft/graphs/contributors)

## Other

https://extiverse.com/extension/nearata/flarum-ext-auth-minecraft
https://discuss.flarum.org/d/27265-minecraft-auth