### PR TITLE
Add `justoverclock/flarum-ext-hashtag`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -448,6 +448,9 @@ return [
 	'justoverclock-guestengagement' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-guestengagement/0.1.7/resources/locale/en.yml',
 	],
+	'justoverclock-hashtag' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-hashtag/0.1.7/resources/locale/en.yml',
+	],
 	'justoverclock-infocards' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-infocards/0.1.4/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/flarum-ext-hashtag` at Packagist](https://packagist.org/packages/justoverclock/flarum-ext-hashtag)

![License](https://img.shields.io/packagist/l/justoverclock/flarum-ext-hashtag)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/flarum-ext-hashtag?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/flarum-ext-hashtag?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/flarum-ext-hashtag)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/flarum-ext-hashtag) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/flarum-ext-hashtag) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/flarum-ext-hashtag)](https://packagist.org/packages/justoverclock/flarum-ext-hashtag/stats)

## [`justoverclockl/flarum-ext-hashtag` at GitHub](https://github.com/justoverclockl/flarum-ext-hashtag)

![GitHub license](https://img.shields.io/github/license/justoverclockl/flarum-ext-hashtag)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/flarum-ext-hashtag)](https://github.com/justoverclockl/flarum-ext-hashtag/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/flarum-ext-hashtag
https://discuss.flarum.org/d/27476-hashtag
