### PR TITLE
Add `2006bt/flarum-ext-login2seeplus`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -22,6 +22,9 @@ return [
 		'https://raw.githubusercontent.com/flarum/core/master/locale/validation.yml',
 	],
 	/* extensions list begin */
+	'2006bt-login2seeplus' => [
+		'tag' => 'https://raw.githubusercontent.com/2006bt/flarum-ext-login2seeplus/v0.2.0/locale/en.yml',
+	],
 	'amaurycarrade-syndication' => [
 		'tag' => 'https://raw.githubusercontent.com/AmauryCarrade/flarum-ext-syndication/v0.3.1/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`2006bt/flarum-ext-login2seeplus` at Packagist](https://packagist.org/packages/2006bt/flarum-ext-login2seeplus)

![License](https://img.shields.io/packagist/l/2006bt/flarum-ext-login2seeplus)

![Latest Stable Version](https://img.shields.io/packagist/v/2006bt/flarum-ext-login2seeplus?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/2006bt/flarum-ext-login2seeplus?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/2006bt/flarum-ext-login2seeplus)
[![Total Downloads](https://img.shields.io/packagist/dt/2006bt/flarum-ext-login2seeplus) ![Monthly Downloads](https://img.shields.io/packagist/dm/2006bt/flarum-ext-login2seeplus) ![Daily Downloads](https://img.shields.io/packagist/dd/2006bt/flarum-ext-login2seeplus)](https://packagist.org/packages/2006bt/flarum-ext-login2seeplus/stats)

## [`2006bt/flarum-ext-login2seeplus` at GitHub](https://github.com/2006bt/flarum-ext-login2seeplus)

![GitHub license](https://img.shields.io/github/license/2006bt/flarum-ext-login2seeplus)

[![GitHub last tag](https://img.shields.io/github/tag-date/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/releases) [![GitHub contributors](https://img.shields.io/github/contributors/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/stargazers) [![GitHub forks](https://img.shields.io/github/forks/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/network) [![GitHub issues](https://img.shields.io/github/issues/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/2006bt/flarum-ext-login2seeplus)](https://github.com/2006bt/flarum-ext-login2seeplus/graphs/contributors)

## Other

https://extiverse.com/extension/2006bt/flarum-ext-login2seeplus
