### PR TITLE
Add Malay language

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ This repository contains raw translations data used by [Weblate](https://weblate
 		</td>
 	</tr>
 	<tr>
+		<td><a href="https://github.com/flarum-lang/malaysian">Malay</a></td>
+		<td><a href="https://github.com/sayuri-gi">Sayuri</a></td>
+		<td align="right">
+			<a href="https://rob006-software.github.io/flarum-translations/status/ms.html" title="Click to see detailed translation status for each extension">
+				<img src="https://weblate.rob006.net/widgets/flarum/ms/svg-badge.svg" alt="detailed translation status" />
+			</a>
+		</td>
+	</tr>
+	<tr>
 		<td><a href="https://github.com/flarum-lang/persian">Persian</a></td>
 		<td><a href="https://github.com/amirrezakhakpour">amirrezakhakpour</a></td>
 		<td align="right">

--- a/config/languages.php
+++ b/config/languages.php
@@ -59,6 +59,7 @@ return [
 	'lt' => getComponents(),
 	'lv' => getComponents(),
 	'ml' => getComponents(),
+	'ms' => getComponents(),
 	'nl' => getComponents([
 		// translations included in extension
 		'!v17development-seo',

--- a/config/subsplits.php
+++ b/config/subsplits.php
@@ -122,6 +122,13 @@ return [
 		'branch' => 'master',
 		'path' => '/locale',
 	],
+	'ms' => [
+		'type' => 'language',
+		'language' => 'ms',
+		'repository' => 'git@github.com:flarum-lang/malaysian.git',
+		'branch' => 'main',
+		'path' => '/locale',
+	],
 	'nl' => [
 		'type' => 'language',
 		'language' => 'nl',


### PR DESCRIPTION
@sayuri-gi Please review this, since I'm not entirely sure that this is what you want. On Weblate there is no definition for Malaysian, there is only Malay. `ms` code that you used also [refers](https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?iso_639_1=ms) to Malay, so this is how I added it. 

However, if there is significant difference between Malaysian and Malay, I could add custom language to Weblate as "Malay (Malaysia)" with `ms_MY` as code.

/cc @justoverclockl 