### PR TITLE
Add `justoverclock/image-gallery`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -487,6 +487,9 @@ return [
 	'justoverclock-header-slideshow' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/header-slideshow/0.1.1/locale/en.yml',
 	],
+	'justoverclock-image-gallery' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/image-gallery/0.1.0/locale/en.yml',
+	],
 	'justoverclock-infocards' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-infocards/0.1.5/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/image-gallery` at Packagist](https://packagist.org/packages/justoverclock/image-gallery)

![License](https://img.shields.io/packagist/l/justoverclock/image-gallery)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/image-gallery?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/image-gallery?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/image-gallery)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/image-gallery) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/image-gallery) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/image-gallery)](https://packagist.org/packages/justoverclock/image-gallery/stats)

## [`justoverclockl/image-gallery` at GitHub](https://github.com/justoverclockl/image-gallery)

![GitHub license](https://img.shields.io/github/license/justoverclockl/image-gallery)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/image-gallery)](https://github.com/justoverclockl/image-gallery/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/image-gallery
https://discuss.flarum.org/d/28232-gallery-from-flickr
