### PR TITLE
Add `justoverclock/last-tweet`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -484,6 +484,9 @@ return [
 	'justoverclock-keywords' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-keywords/1.9.2/resources/locale/en.yml',
 	],
+	'justoverclock-last-tweet' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/last-tweet/0.1.1/locale/en.yml',
+	],
 	'justoverclock-newsfeed' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-newsfeed/1.0.0/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/last-tweet` at Packagist](https://packagist.org/packages/justoverclock/last-tweet)

![License](https://img.shields.io/packagist/l/justoverclock/last-tweet)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/last-tweet?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/last-tweet?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/last-tweet)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/last-tweet) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/last-tweet) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/last-tweet)](https://packagist.org/packages/justoverclock/last-tweet/stats)

## [`justoverclockl/last-tweet` at GitHub](https://github.com/justoverclockl/last-tweet)

![GitHub license](https://img.shields.io/github/license/justoverclockl/last-tweet)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/last-tweet)](https://github.com/justoverclockl/last-tweet/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/last-tweet
https://discuss.flarum.org/d/28438-last-tweets-widget