### PR TITLE
Add `justoverclock/adsense-manager`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -448,6 +448,9 @@ return [
 	'jslirola-login2seeplus' => [
 		'tag' => 'https://raw.githubusercontent.com/jslirola/flarum-ext-login2seeplus/v0.2/locale/en.yml',
 	],
+	'justoverclock-adsense-manager' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/adsense-manager/0.1.5/locale/en.yml',
+	],
 	'justoverclock-contactme' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-contactme/0.2.0/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/adsense-manager` at Packagist](https://packagist.org/packages/justoverclock/adsense-manager)

![License](https://img.shields.io/packagist/l/justoverclock/adsense-manager)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/adsense-manager?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/adsense-manager?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/adsense-manager)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/adsense-manager) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/adsense-manager) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/adsense-manager)](https://packagist.org/packages/justoverclock/adsense-manager/stats)

## [`justoverclockl/adsense-manager` at GitHub](https://github.com/justoverclockl/adsense-manager)

![GitHub license](https://img.shields.io/github/license/justoverclockl/adsense-manager)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/adsense-manager)](https://github.com/justoverclockl/adsense-manager/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/adsense-manager
