### PR TITLE
Add `justoverclock/simple-calendar-widget`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -520,6 +520,9 @@ return [
 	'justoverclock-realtimecode' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-realtimecode/1.0.0/resources/locale/en.yml',
 	],
+	'justoverclock-simple-calendar-widget' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/simple-calendar-widget/0.1.0/locale/en.yml',
+	],
 	'justoverclock-socialcards' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-socialcards/1.0.0/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/simple-calendar-widget` at Packagist](https://packagist.org/packages/justoverclock/simple-calendar-widget)

![License](https://img.shields.io/packagist/l/justoverclock/simple-calendar-widget)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/simple-calendar-widget?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/simple-calendar-widget?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/simple-calendar-widget)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/simple-calendar-widget) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/simple-calendar-widget) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/simple-calendar-widget)](https://packagist.org/packages/justoverclock/simple-calendar-widget/stats)

## [`justoverclockl/simple-calendar-widget` at GitHub](https://github.com/justoverclockl/simple-calendar-widget)

![GitHub license](https://img.shields.io/github/license/justoverclockl/simple-calendar-widget)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/simple-calendar-widget)](https://github.com/justoverclockl/simple-calendar-widget/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/simple-calendar-widget
