### PR TITLE
Add `justoverclock/last-users-posts`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -508,6 +508,9 @@ return [
 	'justoverclock-last-tweet' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/last-tweet/0.1.1/locale/en.yml',
 	],
+	'justoverclock-last-users-posts' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/last-users-posts/0.1.1/locale/en.yml',
+	],
 	'justoverclock-newsfeed' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-newsfeed/1.0.0/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/last-users-posts` at Packagist](https://packagist.org/packages/justoverclock/last-users-posts)

![License](https://img.shields.io/packagist/l/justoverclock/last-users-posts)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/last-users-posts?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/last-users-posts?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/last-users-posts)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/last-users-posts) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/last-users-posts) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/last-users-posts)](https://packagist.org/packages/justoverclock/last-users-posts/stats)

## [`justoverclockl/last-users-posts` at GitHub](https://github.com/justoverclockl/last-users-posts)

![GitHub license](https://img.shields.io/github/license/justoverclockl/last-users-posts)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/last-users-posts)](https://github.com/justoverclockl/last-users-posts/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/last-users-posts
https://discuss.flarum.org/d/28845-last-users-posts-widget