### PR TITLE
Add `justoverclock/last-registered-users`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -514,6 +514,9 @@ return [
 	'justoverclock-keywords' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-keywords/1.9.2/resources/locale/en.yml',
 	],
+	'justoverclock-last-registered-users' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/last-registered-users/0.1.0/locale/en.yml',
+	],
 	'justoverclock-last-tweet' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/last-tweet/0.1.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/last-registered-users` at Packagist](https://packagist.org/packages/justoverclock/last-registered-users)

![License](https://img.shields.io/packagist/l/justoverclock/last-registered-users)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/last-registered-users?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/last-registered-users?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/last-registered-users)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/last-registered-users) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/last-registered-users) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/last-registered-users)](https://packagist.org/packages/justoverclock/last-registered-users/stats)

## [`justoverclockl/last-registered-users` at GitHub](https://github.com/justoverclockl/last-registered-users)

![GitHub license](https://img.shields.io/github/license/justoverclockl/last-registered-users)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/last-registered-users)](https://github.com/justoverclockl/last-registered-users/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/last-registered-users
