### PR TITLE
Add `subasteve/flarum-ext-mailing`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -707,6 +707,9 @@ return [
 	'spookygames-auth-keycloak' => [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.0.0.3/locale/en.yml',
 	],
+	'subasteve-mailing' => [
+		'tag' => 'https://raw.githubusercontent.com/subasteve/flarum-ext-mailing/0.4.2/resources/locale/en.yml',
+	],
 	'sycho-advanced-extension-categories' => [
 		'tag' => 'https://raw.githubusercontent.com/SychO9/flarum-advanced-extension-categories/v0.1.3/locale/en.yml',
 	],


### PR DESCRIPTION
## [`subasteve/flarum-ext-mailing` at Packagist](https://packagist.org/packages/subasteve/flarum-ext-mailing)

![License](https://img.shields.io/packagist/l/subasteve/flarum-ext-mailing)

![Latest Stable Version](https://img.shields.io/packagist/v/subasteve/flarum-ext-mailing?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/subasteve/flarum-ext-mailing?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/subasteve/flarum-ext-mailing)
[![Total Downloads](https://img.shields.io/packagist/dt/subasteve/flarum-ext-mailing) ![Monthly Downloads](https://img.shields.io/packagist/dm/subasteve/flarum-ext-mailing) ![Daily Downloads](https://img.shields.io/packagist/dd/subasteve/flarum-ext-mailing)](https://packagist.org/packages/subasteve/flarum-ext-mailing/stats)

## [`subasteve/flarum-ext-mailing` at GitHub](https://github.com/subasteve/flarum-ext-mailing)

![GitHub license](https://img.shields.io/github/license/subasteve/flarum-ext-mailing)

[![GitHub last tag](https://img.shields.io/github/tag-date/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/releases) [![GitHub contributors](https://img.shields.io/github/contributors/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/stargazers) [![GitHub forks](https://img.shields.io/github/forks/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/network) [![GitHub issues](https://img.shields.io/github/issues/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/subasteve/flarum-ext-mailing)](https://github.com/subasteve/flarum-ext-mailing/graphs/contributors)

## Other

https://extiverse.com/extension/subasteve/flarum-ext-mailing
https://discuss.flarum.org/d/20443
