### PR TITLE
Add `justoverclock/last-post-useravatar`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -585,6 +585,9 @@ return [
 	'justoverclock-keywords' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/flarum-ext-keywords/1.9.4/resources/locale/en.yml',
 	],
+	'justoverclock-last-post-useravatar' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/last-post-useravatar/0.1.0/locale/en.yml',
+	],
 	'justoverclock-last-registered-users' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/last-registered-users/0.1.4/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/last-post-useravatar` at Packagist](https://packagist.org/packages/justoverclock/last-post-useravatar)

![License](https://img.shields.io/packagist/l/justoverclock/last-post-useravatar)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/last-post-useravatar?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/last-post-useravatar?include_prereleases&label=unstable) ![Flarum compatibility status](https://flarum-badge-api.davwheat.dev/v1/compat-latest/justoverclock/last-post-useravatar)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/last-post-useravatar) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/last-post-useravatar) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/last-post-useravatar)](https://packagist.org/packages/justoverclock/last-post-useravatar/stats)

## [`justoverclockl/last-post-useravatar` at GitHub](https://github.com/justoverclockl/last-post-useravatar)

![GitHub license](https://img.shields.io/github/license/justoverclockl/last-post-useravatar)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/last-post-useravatar)](https://github.com/justoverclockl/last-post-useravatar/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/last-post-useravatar
https://discuss.flarum.org/d/29744-last-posted-user-avatar-in-discussionlist