### PR TITLE
Add `justoverclock/best-answer-badge`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -653,6 +653,9 @@ return [
 	'justoverclock-auto-post-count-badge' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/auto-post-count-badge/0.1.9/locale/en.yml',
 	],
+	'justoverclock-best-answer-badge' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/best-answer-badge/0.1.0/locale/en.yml',
+	],
 	'justoverclock-broken-links-checker' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/broken-links-checker/0.1.2/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/best-answer-badge` at Packagist](https://packagist.org/packages/justoverclock/best-answer-badge)

![License](https://img.shields.io/packagist/l/justoverclock/best-answer-badge)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/best-answer-badge?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/best-answer-badge?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/best-answer-badge) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/best-answer-badge) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/best-answer-badge)](https://packagist.org/packages/justoverclock/best-answer-badge/stats)

## [`justoverclockl/best-answer-badge` at GitHub](https://github.com/justoverclockl/best-answer-badge)

![GitHub license](https://img.shields.io/github/license/justoverclockl/best-answer-badge)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/best-answer-badge)](https://github.com/justoverclockl/best-answer-badge/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/best-answer-badge
https://discuss.flarum.org/d/31268-best-answer-badge