### PR TITLE
Add `3ddario/flarum-ext-tag-color-swiss-army-knife`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -22,6 +22,9 @@ return [
 		'https://raw.githubusercontent.com/flarum/flarum-core/v1.3.1/locale/validation.yml',
 	],
 	/* extensions list begin */
+	'3ddario-tag-color-swiss-army-knife' => [
+		'tag' => 'https://raw.githubusercontent.com/3DDario/flarum-ext-tag-color-swiss-army-knife/v1.1.0/locale/en.yml',
+	],
 	'acpl-lscache' => [
 		'tag' => 'https://raw.githubusercontent.com/android-com-pl/flarum-lscache/0.4.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`3ddario/flarum-ext-tag-color-swiss-army-knife` at Packagist](https://packagist.org/packages/3ddario/flarum-ext-tag-color-swiss-army-knife)

![License](https://img.shields.io/packagist/l/3ddario/flarum-ext-tag-color-swiss-army-knife)

![Latest Stable Version](https://img.shields.io/packagist/v/3ddario/flarum-ext-tag-color-swiss-army-knife?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/3ddario/flarum-ext-tag-color-swiss-army-knife?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/3ddario/flarum-ext-tag-color-swiss-army-knife) ![Monthly Downloads](https://img.shields.io/packagist/dm/3ddario/flarum-ext-tag-color-swiss-army-knife) ![Daily Downloads](https://img.shields.io/packagist/dd/3ddario/flarum-ext-tag-color-swiss-army-knife)](https://packagist.org/packages/3ddario/flarum-ext-tag-color-swiss-army-knife/stats)

## [`3DDario/flarum-ext-tag-color-swiss-army-knife` at GitHub](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife)

![GitHub license](https://img.shields.io/github/license/3DDario/flarum-ext-tag-color-swiss-army-knife)

[![GitHub last tag](https://img.shields.io/github/tag-date/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/releases) [![GitHub contributors](https://img.shields.io/github/contributors/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/stargazers) [![GitHub forks](https://img.shields.io/github/forks/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/network) [![GitHub issues](https://img.shields.io/github/issues/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/3DDario/flarum-ext-tag-color-swiss-army-knife)](https://github.com/3DDario/flarum-ext-tag-color-swiss-army-knife/graphs/contributors)

## Other

https://extiverse.com/extension/3ddario/flarum-ext-tag-color-swiss-army-knife
