### PR TITLE
Add `lodge104/flarum-ext-oauth-auth0`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -895,6 +895,9 @@ return [
 	'littlecxm-reply-to-see' => [
 		'tag' => 'https://raw.githubusercontent.com/littlecxm/flarum-reply-to-see/1.0.2/resources/locale/en.yml',
 	],
+	'lodge104-oauth-auth0' => [
+		'tag' => 'https://raw.githubusercontent.com/Lodge104/flarum-ext-oauth-auth0/v1.0.2/locale/en.yml',
+	],
 	'maicol07-oidc-client' => [
 		'tag' => 'https://raw.githubusercontent.com/extiverse/premium-translations/master/maicol07-oidc-client.yml',
 	],


### PR DESCRIPTION
## [`lodge104/flarum-ext-oauth-auth0` at Packagist](https://packagist.org/packages/lodge104/flarum-ext-oauth-auth0)

![License](https://img.shields.io/packagist/l/lodge104/flarum-ext-oauth-auth0)

![Latest Stable Version](https://img.shields.io/packagist/v/lodge104/flarum-ext-oauth-auth0?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/lodge104/flarum-ext-oauth-auth0?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/lodge104/flarum-ext-oauth-auth0) ![Monthly Downloads](https://img.shields.io/packagist/dm/lodge104/flarum-ext-oauth-auth0) ![Daily Downloads](https://img.shields.io/packagist/dd/lodge104/flarum-ext-oauth-auth0)](https://packagist.org/packages/lodge104/flarum-ext-oauth-auth0/stats)

## [`Lodge104/flarum-ext-oauth-auth0` at GitHub](https://github.com/Lodge104/flarum-ext-oauth-auth0)

![GitHub license](https://img.shields.io/github/license/Lodge104/flarum-ext-oauth-auth0)

[![GitHub last tag](https://img.shields.io/github/tag-date/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/network) [![GitHub issues](https://img.shields.io/github/issues/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Lodge104/flarum-ext-oauth-auth0)](https://github.com/Lodge104/flarum-ext-oauth-auth0/graphs/contributors)

## Other

https://extiverse.com/extension/lodge104/flarum-ext-oauth-auth0
