### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/verify-config.yml
+++ b/.github/workflows/verify-config.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/verify-config.yml
+++ b/.github/workflows/verify-config.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Cache builder
         id: builder-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: builder
           key: ${{ runner.os }}-builder-${{ env.DATE }}


### PR DESCRIPTION
> The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2