### PR TITLE
Add `nearata/flarum-ext-discord-widget`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -992,6 +992,9 @@ return [
 	'nearata-copy-code-to-clipboard' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-copy-code-to-clipboard/v2.1.0/resources/locale/en.yml',
 	],
+	'nearata-discord-widget' => [
+		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-discord-widget/v1.0.0/locale/en.yml',
+	],
 	'nearata-dsts' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-dsts/v2.3.0/locale/en.yml',
 	],


### PR DESCRIPTION
## [`nearata/flarum-ext-discord-widget` at Packagist](https://packagist.org/packages/nearata/flarum-ext-discord-widget)

![License](https://img.shields.io/packagist/l/nearata/flarum-ext-discord-widget)

![Latest Stable Version](https://img.shields.io/packagist/v/nearata/flarum-ext-discord-widget?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/nearata/flarum-ext-discord-widget?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/nearata/flarum-ext-discord-widget) ![Monthly Downloads](https://img.shields.io/packagist/dm/nearata/flarum-ext-discord-widget) ![Daily Downloads](https://img.shields.io/packagist/dd/nearata/flarum-ext-discord-widget)](https://packagist.org/packages/nearata/flarum-ext-discord-widget/stats)

## [`Nearata/flarum-ext-discord-widget` at GitHub](https://github.com/Nearata/flarum-ext-discord-widget)

![GitHub license](https://img.shields.io/github/license/Nearata/flarum-ext-discord-widget)

[![GitHub last tag](https://img.shields.io/github/tag-date/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/network) [![GitHub issues](https://img.shields.io/github/issues/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Nearata/flarum-ext-discord-widget)](https://github.com/Nearata/flarum-ext-discord-widget/graphs/contributors)

## Other

https://extiverse.com/extension/nearata/flarum-ext-discord-widget
