### PR TITLE
Add `justoverclock/be-active-user-indicator`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -734,6 +734,9 @@ return [
 	'justoverclock-auto-post-count-badge' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/auto-post-count-badge/0.2.0/locale/en.yml',
 	],
+	'justoverclock-be-active-user-indicator' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/active-user-indicator/0.1.0/locale/en.yml',
+	],
 	'justoverclock-best-answer-badge' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/best-answer-badge/0.1.0/locale/en.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/be-active-user-indicator` at Packagist](https://packagist.org/packages/justoverclock/be-active-user-indicator)

![License](https://img.shields.io/packagist/l/justoverclock/be-active-user-indicator)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/be-active-user-indicator?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/be-active-user-indicator?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/be-active-user-indicator) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/be-active-user-indicator) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/be-active-user-indicator)](https://packagist.org/packages/justoverclock/be-active-user-indicator/stats)

## [`justoverclockl/active-user-indicator` at GitHub](https://github.com/justoverclockl/active-user-indicator)

![GitHub license](https://img.shields.io/github/license/justoverclockl/active-user-indicator)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/active-user-indicator)](https://github.com/justoverclockl/active-user-indicator/graphs/contributors)

## Other

https://extiverse.com/extension/justoverclock/be-active-user-indicator
https://discuss.flarum.org/d/32598-backend-userslist-visual-active-account-indicator