### PR TITLE
Add `nearata/flarum-ext-sensitive-content`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1022,6 +1022,9 @@ return [
 	'nearata-related-discussions' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-related-discussions/1.3.0/locale/en.yml',
 	],
+	'nearata-sensitive-content' => [
+		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-sensitive-content/1.0.0/locale/en.yml',
+	],
 	'nearata-signup-confirm-password' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-signup-confirm-password/v3.0.1/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`nearata/flarum-ext-sensitive-content` at Packagist](https://packagist.org/packages/nearata/flarum-ext-sensitive-content)

![License](https://img.shields.io/packagist/l/nearata/flarum-ext-sensitive-content)

![Latest Stable Version](https://img.shields.io/packagist/v/nearata/flarum-ext-sensitive-content?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/nearata/flarum-ext-sensitive-content?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/nearata/flarum-ext-sensitive-content) ![Monthly Downloads](https://img.shields.io/packagist/dm/nearata/flarum-ext-sensitive-content) ![Daily Downloads](https://img.shields.io/packagist/dd/nearata/flarum-ext-sensitive-content)](https://packagist.org/packages/nearata/flarum-ext-sensitive-content/stats)

## [`Nearata/flarum-ext-sensitive-content` at GitHub](https://github.com/Nearata/flarum-ext-sensitive-content)

![GitHub license](https://img.shields.io/github/license/Nearata/flarum-ext-sensitive-content)

[![GitHub last tag](https://img.shields.io/github/tag-date/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/network) [![GitHub issues](https://img.shields.io/github/issues/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Nearata/flarum-ext-sensitive-content)](https://github.com/Nearata/flarum-ext-sensitive-content/graphs/contributors)

## Other

https://extiverse.com/extension/nearata/flarum-ext-sensitive-content
