### PR TITLE
Add `nearata/flarum-ext-gif-avatars`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1028,6 +1028,9 @@ return [
 	'nearata-embed-video' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-embed-video/3.3.2/locale/en.yml',
 	],
+	'nearata-gif-avatars' => [
+		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-gif-avatars/1.0.0/locale/en.yml',
+	],
 	'nearata-minecraft-avatars' => [
 		'tag' => 'https://raw.githubusercontent.com/Nearata/flarum-ext-minecraft-avatars/v2.1.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`nearata/flarum-ext-gif-avatars` at Packagist](https://packagist.org/packages/nearata/flarum-ext-gif-avatars)

![License](https://img.shields.io/packagist/l/nearata/flarum-ext-gif-avatars)

![Latest Stable Version](https://img.shields.io/packagist/v/nearata/flarum-ext-gif-avatars?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/nearata/flarum-ext-gif-avatars?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/nearata/flarum-ext-gif-avatars) ![Monthly Downloads](https://img.shields.io/packagist/dm/nearata/flarum-ext-gif-avatars) ![Daily Downloads](https://img.shields.io/packagist/dd/nearata/flarum-ext-gif-avatars)](https://packagist.org/packages/nearata/flarum-ext-gif-avatars/stats)

## [`Nearata/flarum-ext-gif-avatars` at GitHub](https://github.com/Nearata/flarum-ext-gif-avatars)

![GitHub license](https://img.shields.io/github/license/Nearata/flarum-ext-gif-avatars)

[![GitHub last tag](https://img.shields.io/github/tag-date/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/network) [![GitHub issues](https://img.shields.io/github/issues/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Nearata/flarum-ext-gif-avatars)](https://github.com/Nearata/flarum-ext-gif-avatars/graphs/contributors)

## Other

https://extiverse.com/extension/nearata/flarum-ext-gif-avatars
