### PR TITLE
Add `blomstra/database-queue`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -103,6 +103,9 @@ return [
 	'blomstra-conversations' => [
 		'tag' => 'https://raw.githubusercontent.com/blomstra/flarum-ext-conversations/0.1.2/locale/en.yml',
 	],
+	'blomstra-database-queue' => [
+		'tag' => 'https://raw.githubusercontent.com/blomstra/flarum-ext-database-queue/1.0.0/resources/locale/en.yml',
+	],
 	'blomstra-flag-duplicates' => [
 		'tag' => 'https://raw.githubusercontent.com/blomstra/flarum-ext-flag-duplicate/0.2.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`blomstra/database-queue` at Packagist](https://packagist.org/packages/blomstra/database-queue)

![License](https://img.shields.io/packagist/l/blomstra/database-queue)

![Latest Stable Version](https://img.shields.io/packagist/v/blomstra/database-queue?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/blomstra/database-queue?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/blomstra/database-queue) ![Monthly Downloads](https://img.shields.io/packagist/dm/blomstra/database-queue) ![Daily Downloads](https://img.shields.io/packagist/dd/blomstra/database-queue)](https://packagist.org/packages/blomstra/database-queue/stats)

## [`blomstra/flarum-ext-database-queue` at GitHub](https://github.com/blomstra/flarum-ext-database-queue)

![GitHub license](https://img.shields.io/github/license/blomstra/flarum-ext-database-queue)

[![GitHub last tag](https://img.shields.io/github/tag-date/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/releases) [![GitHub contributors](https://img.shields.io/github/contributors/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/stargazers) [![GitHub forks](https://img.shields.io/github/forks/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/network) [![GitHub issues](https://img.shields.io/github/issues/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/blomstra/flarum-ext-database-queue)](https://github.com/blomstra/flarum-ext-database-queue/graphs/contributors)

## Other

https://extiverse.com/extension/blomstra/database-queue
https://discuss.flarum.org/d/28151-database-queue-the-simplest-queue-even-for-shared-hosting
