### PR TITLE
Add `mattoid/flarum-ext-operate-log`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1048,6 +1048,9 @@ return [
 	'matteocontrini-imgur-upload' => [
 		'tag' => 'https://raw.githubusercontent.com/matteocontrini/flarum-imgur-upload/v3.9.1/locale/en.yml',
 	],
+	'mattoid-operate-log' => [
+		'tag' => 'https://raw.githubusercontent.com/Mattoids/flarum-ext-operate-log/v1.0.0/locale/en.yml',
+	],
 	'michaelbelgium-discussion-views' => [
 		'tag' => 'https://raw.githubusercontent.com/MichaelBelgium/flarum-discussion-views/v7.2.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`mattoid/flarum-ext-operate-log` at Packagist](https://packagist.org/packages/mattoid/flarum-ext-operate-log)

![License](https://img.shields.io/packagist/l/mattoid/flarum-ext-operate-log)

![Latest Stable Version](https://img.shields.io/packagist/v/mattoid/flarum-ext-operate-log?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/mattoid/flarum-ext-operate-log?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/mattoid/flarum-ext-operate-log) ![Monthly Downloads](https://img.shields.io/packagist/dm/mattoid/flarum-ext-operate-log) ![Daily Downloads](https://img.shields.io/packagist/dd/mattoid/flarum-ext-operate-log)](https://packagist.org/packages/mattoid/flarum-ext-operate-log/stats)

## [`Mattoids/flarum-ext-operate-log` at GitHub](https://github.com/Mattoids/flarum-ext-operate-log)

![GitHub license](https://img.shields.io/github/license/Mattoids/flarum-ext-operate-log)

[![GitHub last tag](https://img.shields.io/github/tag-date/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/releases) [![GitHub contributors](https://img.shields.io/github/contributors/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/stargazers) [![GitHub forks](https://img.shields.io/github/forks/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/network) [![GitHub issues](https://img.shields.io/github/issues/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/Mattoids/flarum-ext-operate-log)](https://github.com/Mattoids/flarum-ext-operate-log/graphs/contributors)

## Other

https://extiverse.com/extension/mattoid/flarum-ext-operate-log
