### PR TITLE
Add `ianm/boring-avatars`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -739,6 +739,9 @@ return [
 	'hikarilan-passkey-login' => [
 		'tag' => 'https://raw.githubusercontent.com/shaokeyibb/flarum-passkey-login/0.2/locale/en.yml',
 	],
+	'ianm-boring-avatars' => [
+		'tag' => 'https://raw.githubusercontent.com/imorland/flarum-ext-boring-avatars/1.0.0/locale/en.yml',
+	],
 	'ianm-follow-users' => [
 		'tag' => 'https://raw.githubusercontent.com/imorland/follow-users/1.4.4/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`ianm/boring-avatars` at Packagist](https://packagist.org/packages/ianm/boring-avatars)

![License](https://img.shields.io/packagist/l/ianm/boring-avatars)

![Latest Stable Version](https://img.shields.io/packagist/v/ianm/boring-avatars?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ianm/boring-avatars?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ianm/boring-avatars) ![Monthly Downloads](https://img.shields.io/packagist/dm/ianm/boring-avatars) ![Daily Downloads](https://img.shields.io/packagist/dd/ianm/boring-avatars)](https://packagist.org/packages/ianm/boring-avatars/stats)

## [`imorland/flarum-ext-boring-avatars` at GitHub](https://github.com/imorland/flarum-ext-boring-avatars)

![GitHub license](https://img.shields.io/github/license/imorland/flarum-ext-boring-avatars)

[![GitHub last tag](https://img.shields.io/github/tag-date/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/releases) [![GitHub contributors](https://img.shields.io/github/contributors/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/stargazers) [![GitHub forks](https://img.shields.io/github/forks/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/network) [![GitHub issues](https://img.shields.io/github/issues/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/imorland/flarum-ext-boring-avatars)](https://github.com/imorland/flarum-ext-boring-avatars/graphs/contributors)

## Other

https://extiverse.com/extension/ianm/boring-avatars
https://discuss.flarum.org/d/33989-boring-avatars-self-hosted-generated-avatars-based-on-various-themes