### PR TITLE
Add `gtdxyz/flarum-ext-logo-boost`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -736,6 +736,9 @@ return [
 	'glowingblue-redis-setup' => [
 		'tag' => 'https://raw.githubusercontent.com/glowingblue/flarum-ext-redis-setup/1.2.2/resources/locale/en.yml',
 	],
+	'gtdxyz-logo-boost' => [
+		'tag' => 'https://raw.githubusercontent.com/daocatt/flarum-ext-logo-boost/1.0/locale/en.yml',
+	],
 	'hehongyuanlove-auth-qq' => [
 		'tag' => 'https://raw.githubusercontent.com/Hehongyuanlove/flarum-auth-qq/2.5.1/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`gtdxyz/flarum-ext-logo-boost` at Packagist](https://packagist.org/packages/gtdxyz/flarum-ext-logo-boost)

![License](https://img.shields.io/packagist/l/gtdxyz/flarum-ext-logo-boost)

![Latest Stable Version](https://img.shields.io/packagist/v/gtdxyz/flarum-ext-logo-boost?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/gtdxyz/flarum-ext-logo-boost?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/gtdxyz/flarum-ext-logo-boost) ![Monthly Downloads](https://img.shields.io/packagist/dm/gtdxyz/flarum-ext-logo-boost) ![Daily Downloads](https://img.shields.io/packagist/dd/gtdxyz/flarum-ext-logo-boost)](https://packagist.org/packages/gtdxyz/flarum-ext-logo-boost/stats)

## [`daocatt/flarum-ext-logo-boost` at GitHub](https://github.com/daocatt/flarum-ext-logo-boost)

![GitHub license](https://img.shields.io/github/license/daocatt/flarum-ext-logo-boost)

[![GitHub last tag](https://img.shields.io/github/tag-date/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/releases) [![GitHub contributors](https://img.shields.io/github/contributors/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/stargazers) [![GitHub forks](https://img.shields.io/github/forks/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/network) [![GitHub issues](https://img.shields.io/github/issues/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/daocatt/flarum-ext-logo-boost)](https://github.com/daocatt/flarum-ext-logo-boost/graphs/contributors)

## Other

https://extiverse.com/extension/gtdxyz/flarum-ext-logo-boost
