### PR TITLE
Add `ssangyongsports/oauth-logto`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1231,6 +1231,9 @@ return [
 	'spookygames-auth-keycloak' => [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.3.0.1/locale/en.yml',
 	],
+	'ssangyongsports-oauth-logto' => [
+		'tag' => 'https://raw.githubusercontent.com/ssangyongsportsorg/flarum-ext-oauth-logto/1/locale/en.yml',
+	],
 	'swaggymacro-only-starter' => [
 		'tag' => 'https://raw.githubusercontent.com/SwaggyMacro/OnlyStarter/0.6.6/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`ssangyongsports/oauth-logto` at Packagist](https://packagist.org/packages/ssangyongsports/oauth-logto)

![License](https://img.shields.io/packagist/l/ssangyongsports/oauth-logto)

![Latest Stable Version](https://img.shields.io/packagist/v/ssangyongsports/oauth-logto?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ssangyongsports/oauth-logto?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ssangyongsports/oauth-logto) ![Monthly Downloads](https://img.shields.io/packagist/dm/ssangyongsports/oauth-logto) ![Daily Downloads](https://img.shields.io/packagist/dd/ssangyongsports/oauth-logto)](https://packagist.org/packages/ssangyongsports/oauth-logto/stats)

## [`ssangyongsportsorg/flarum-ext-oauth-logto` at GitHub](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto)

![GitHub license](https://img.shields.io/github/license/ssangyongsportsorg/flarum-ext-oauth-logto)

[![GitHub last tag](https://img.shields.io/github/tag-date/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/network) [![GitHub issues](https://img.shields.io/github/issues/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ssangyongsportsorg/flarum-ext-oauth-logto)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-logto/graphs/contributors)

## Other

https://flarum.org/extension/ssangyongsports/oauth-logto
