### PR TITLE
Add `ssport/oauth-slack`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1231,6 +1231,9 @@ return [
 	'spookygames-auth-keycloak' => [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.3.0.1/locale/en.yml',
 	],
+	'ssport-oauth-slack' => [
+		'tag' => 'https://raw.githubusercontent.com/ssangyongsportsorg/flarum-ext-oauth-slack/1/locale/en.yml',
+	],
 	'swaggymacro-only-starter' => [
 		'tag' => 'https://raw.githubusercontent.com/SwaggyMacro/OnlyStarter/0.6.6/resources/locale/en.yml',
 	],

--- a/config/components.php
+++ b/config/components.php
@@ -1232,7 +1232,7 @@ return [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.3.0.1/locale/en.yml',
 	],
 	'ssport-oauth-slack' => [
-		'tag' => 'https://raw.githubusercontent.com/ssangyongsportsorg/flarum-ext-oauth-slack/1/locale/en.yml',
+		'tag' => 'https://raw.githubusercontent.com/ssangyongsportsorg/flarum-ext-oauth-slack/2/locale/en.yml',
 	],
 	'swaggymacro-only-starter' => [
 		'tag' => 'https://raw.githubusercontent.com/SwaggyMacro/OnlyStarter/0.6.6/resources/locale/en.yml',


### PR DESCRIPTION
## [`ssport/oauth-slack` at Packagist](https://packagist.org/packages/ssport/oauth-slack)

![License](https://img.shields.io/packagist/l/ssport/oauth-slack)

![Latest Stable Version](https://img.shields.io/packagist/v/ssport/oauth-slack?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ssport/oauth-slack?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ssport/oauth-slack) ![Monthly Downloads](https://img.shields.io/packagist/dm/ssport/oauth-slack) ![Daily Downloads](https://img.shields.io/packagist/dd/ssport/oauth-slack)](https://packagist.org/packages/ssport/oauth-slack/stats)

## [`ssangyongsportsorg/flarum-ext-oauth-slack` at GitHub](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack)

![GitHub license](https://img.shields.io/github/license/ssangyongsportsorg/flarum-ext-oauth-slack)

[![GitHub last tag](https://img.shields.io/github/tag-date/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/network) [![GitHub issues](https://img.shields.io/github/issues/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ssangyongsportsorg/flarum-ext-oauth-slack)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-slack/graphs/contributors)

## Other

https://flarum.org/extension/ssport/oauth-slack
