### PR TITLE
Add `ssport/s`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1231,6 +1231,9 @@ return [
 	'spookygames-auth-keycloak' => [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.3.0.1/locale/en.yml',
 	],
+	'ssport-s' => [
+		'tag' => 'https://raw.githubusercontent.com/ssangyongsportsorg/flarum-ext-oauth-clerk/1/locale/en.yml',
+	],
 	'swaggymacro-only-starter' => [
 		'tag' => 'https://raw.githubusercontent.com/SwaggyMacro/OnlyStarter/0.6.6/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`ssport/s` at Packagist](https://packagist.org/packages/ssport/s)

![License](https://img.shields.io/packagist/l/ssport/s)

![Latest Stable Version](https://img.shields.io/packagist/v/ssport/s?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ssport/s?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ssport/s) ![Monthly Downloads](https://img.shields.io/packagist/dm/ssport/s) ![Daily Downloads](https://img.shields.io/packagist/dd/ssport/s)](https://packagist.org/packages/ssport/s/stats)

## [`ssangyongsportsorg/flarum-ext-oauth-clerk` at GitHub](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk)

![GitHub license](https://img.shields.io/github/license/ssangyongsportsorg/flarum-ext-oauth-clerk)

[![GitHub last tag](https://img.shields.io/github/tag-date/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/network) [![GitHub issues](https://img.shields.io/github/issues/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ssangyongsportsorg/flarum-ext-oauth-clerk)](https://github.com/ssangyongsportsorg/flarum-ext-oauth-clerk/graphs/contributors)

## Other

https://flarum.org/extension/ssport/s
