### PR TITLE
Add `ssports/oauth-slack`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1249,6 +1249,9 @@ return [
 	'spookygames-auth-keycloak' => [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.3.0.1/locale/en.yml',
 	],
+	'ssports-oauth-slack' => [
+		'tag' => 'https://raw.githubusercontent.com/ssangyongsport/flarum-ext-oauth-slack/1/locale/en.yml',
+	],
 	'swaggymacro-only-starter' => [
 		'tag' => 'https://raw.githubusercontent.com/SwaggyMacro/OnlyStarter/0.6.6/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`ssports/oauth-slack` at Packagist](https://packagist.org/packages/ssports/oauth-slack)

![License](https://img.shields.io/packagist/l/ssports/oauth-slack)

![Latest Stable Version](https://img.shields.io/packagist/v/ssports/oauth-slack?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ssports/oauth-slack?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ssports/oauth-slack) ![Monthly Downloads](https://img.shields.io/packagist/dm/ssports/oauth-slack) ![Daily Downloads](https://img.shields.io/packagist/dd/ssports/oauth-slack)](https://packagist.org/packages/ssports/oauth-slack/stats)

## [`ssangyongsport/flarum-ext-oauth-slack` at GitHub](https://github.com/ssangyongsport/flarum-ext-oauth-slack)

![GitHub license](https://img.shields.io/github/license/ssangyongsport/flarum-ext-oauth-slack)

[![GitHub last tag](https://img.shields.io/github/tag-date/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/network) [![GitHub issues](https://img.shields.io/github/issues/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ssangyongsport/flarum-ext-oauth-slack)](https://github.com/ssangyongsport/flarum-ext-oauth-slack/graphs/contributors)

## Other

https://flarum.org/extension/ssports/oauth-slack
