### PR TITLE
Add `ssportd/oauth-slack`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1250,7 +1250,7 @@ return [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.3.0.1/locale/en.yml',
 	],
 	'ssportd-oauth-slack' => [
-		'tag' => 'https://raw.githubusercontent.com/ssangyongsport/flarum-ext-oauth-slack-Sls/1/locale/en.yml',
+		'tag' => 'https://raw.githubusercontent.com/ssangyongsport/flarum-ext-oauth-slack-Sls/2/locale/en.yml',
 	],
 	'swaggymacro-only-starter' => [
 		'tag' => 'https://raw.githubusercontent.com/SwaggyMacro/OnlyStarter/0.6.6/resources/locale/en.yml',


### PR DESCRIPTION
## [`ssportd/oauth-slack` at Packagist](https://packagist.org/packages/ssportd/oauth-slack)

![License](https://img.shields.io/packagist/l/ssportd/oauth-slack)

![Latest Stable Version](https://img.shields.io/packagist/v/ssportd/oauth-slack?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ssportd/oauth-slack?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ssportd/oauth-slack) ![Monthly Downloads](https://img.shields.io/packagist/dm/ssportd/oauth-slack) ![Daily Downloads](https://img.shields.io/packagist/dd/ssportd/oauth-slack)](https://packagist.org/packages/ssportd/oauth-slack/stats)

## [`ssangyongsport/flarum-ext-oauth-slack-Sls` at GitHub](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls)

![GitHub license](https://img.shields.io/github/license/ssangyongsport/flarum-ext-oauth-slack-Sls)

[![GitHub last tag](https://img.shields.io/github/tag-date/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/network) [![GitHub issues](https://img.shields.io/github/issues/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ssangyongsport/flarum-ext-oauth-slack-Sls)](https://github.com/ssangyongsport/flarum-ext-oauth-slack-Sls/graphs/contributors)

## Other

https://flarum.org/extension/ssportd/oauth-slack
