### PR TITLE
Add `ssport/oauth-generic`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1249,6 +1249,9 @@ return [
 	'spookygames-auth-keycloak' => [
 		'tag' => 'https://raw.githubusercontent.com/spookygames/flarum-ext-auth-keycloak/1.3.0.1/locale/en.yml',
 	],
+	'ssport-oauth-generic' => [
+		'tag' => 'https://raw.githubusercontent.com/ssangyongsportsteam/flarum-ext-oauth-generic/1/locale/en.yml',
+	],
 	'swaggymacro-only-starter' => [
 		'tag' => 'https://raw.githubusercontent.com/SwaggyMacro/OnlyStarter/0.6.6/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`ssport/oauth-generic` at Packagist](https://packagist.org/packages/ssport/oauth-generic)

![License](https://img.shields.io/packagist/l/ssport/oauth-generic)

![Latest Stable Version](https://img.shields.io/packagist/v/ssport/oauth-generic?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ssport/oauth-generic?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ssport/oauth-generic) ![Monthly Downloads](https://img.shields.io/packagist/dm/ssport/oauth-generic) ![Daily Downloads](https://img.shields.io/packagist/dd/ssport/oauth-generic)](https://packagist.org/packages/ssport/oauth-generic/stats)

## [`ssangyongsportsteam/flarum-ext-oauth-generic` at GitHub](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic)

![GitHub license](https://img.shields.io/github/license/ssangyongsportsteam/flarum-ext-oauth-generic)

[![GitHub last tag](https://img.shields.io/github/tag-date/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/network) [![GitHub issues](https://img.shields.io/github/issues/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ssangyongsportsteam/flarum-ext-oauth-generic)](https://github.com/ssangyongsportsteam/flarum-ext-oauth-generic/graphs/contributors)

## Other

https://flarum.org/extension/ssport/oauth-generic
