### PR TITLE
Add `gbcl/minecraft-oauth`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -742,6 +742,9 @@ return [
 	'ganuonglachanh-sonic' => [
 		'tag' => 'https://raw.githubusercontent.com/ganuonglachanh/flarum-sonic/0.1.9/resources/locale/en.yml',
 	],
+	'gbcl-minecraft-oauth' => [
+		'tag' => 'https://raw.githubusercontent.com/GBCLStudio/Flarum-MinecraftAuth/1.0.0/locale/en.yml',
+	],
 	'gbcl-userip' => [
 		'tag' => 'https://raw.githubusercontent.com/GBCLStudio/userip/1.1.0/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`gbcl/minecraft-oauth` at Packagist](https://packagist.org/packages/gbcl/minecraft-oauth)

![License](https://img.shields.io/packagist/l/gbcl/minecraft-oauth)

![Latest Stable Version](https://img.shields.io/packagist/v/gbcl/minecraft-oauth?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/gbcl/minecraft-oauth?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/gbcl/minecraft-oauth) ![Monthly Downloads](https://img.shields.io/packagist/dm/gbcl/minecraft-oauth) ![Daily Downloads](https://img.shields.io/packagist/dd/gbcl/minecraft-oauth)](https://packagist.org/packages/gbcl/minecraft-oauth/stats)

## [`GBCLStudio/Flarum-MinecraftAuth` at GitHub](https://github.com/GBCLStudio/Flarum-MinecraftAuth)

![GitHub license](https://img.shields.io/github/license/GBCLStudio/Flarum-MinecraftAuth)

[![GitHub last tag](https://img.shields.io/github/tag-date/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/releases) [![GitHub contributors](https://img.shields.io/github/contributors/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/stargazers) [![GitHub forks](https://img.shields.io/github/forks/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/network) [![GitHub issues](https://img.shields.io/github/issues/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/GBCLStudio/Flarum-MinecraftAuth)](https://github.com/GBCLStudio/Flarum-MinecraftAuth/graphs/contributors)

## Other

https://flarum.org/extension/gbcl/minecraft-oauth
https://discuss.flarum.org/d/35382-minecraft-oauth