### PR TITLE
Add `nodeloc/oauth-telegram`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1241,6 +1241,9 @@ return [
 	'nodeloc-my-emoji' => [
 		'tag' => 'https://raw.githubusercontent.com/nodeloc/flarum-ext-my-emoji/1.0.2/locale/en.yml',
 	],
+	'nodeloc-oauth-telegram' => [
+		'tag' => 'https://raw.githubusercontent.com/nodeloc/flarum-ext-oauth-telegram/0.0.1/locale/en.yml',
+	],
 	'nodeloc-referral' => [
 		'tag' => 'https://raw.githubusercontent.com/nodeloc/flarum-ext-referral/0.0.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`nodeloc/oauth-telegram` at Packagist](https://packagist.org/packages/nodeloc/oauth-telegram)

![License](https://img.shields.io/packagist/l/nodeloc/oauth-telegram)

![Latest Stable Version](https://img.shields.io/packagist/v/nodeloc/oauth-telegram?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/nodeloc/oauth-telegram?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/nodeloc/oauth-telegram) ![Monthly Downloads](https://img.shields.io/packagist/dm/nodeloc/oauth-telegram) ![Daily Downloads](https://img.shields.io/packagist/dd/nodeloc/oauth-telegram)](https://packagist.org/packages/nodeloc/oauth-telegram/stats)

## [`nodeloc/flarum-ext-oauth-telegram` at GitHub](https://github.com/nodeloc/flarum-ext-oauth-telegram)

![GitHub license](https://img.shields.io/github/license/nodeloc/flarum-ext-oauth-telegram)

[![GitHub last tag](https://img.shields.io/github/tag-date/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/releases) [![GitHub contributors](https://img.shields.io/github/contributors/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/stargazers) [![GitHub forks](https://img.shields.io/github/forks/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/network) [![GitHub issues](https://img.shields.io/github/issues/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/nodeloc/flarum-ext-oauth-telegram)](https://github.com/nodeloc/flarum-ext-oauth-telegram/graphs/contributors)

## Other

https://flarum.org/extension/nodeloc/oauth-telegram
