### PR TITLE
Add `justoverclock/stats`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1016,6 +1016,9 @@ return [
 	'justoverclock-staff-members-widget' => [
 		'tag' => 'https://raw.githubusercontent.com/justoverclockl/staff-member-widget/0.1.3/locale/en.yml',
 	],
+	'justoverclock-stats' => [
+		'tag' => 'https://raw.githubusercontent.com/justoverclockl/stats/1.0.1/locale/en.yml',
+	],
 	'justoverclock-steam-api' => [
 		'tag' => 'https://raw.githubusercontent.com/flarum-com/premium-translations/bef89cfb5e916b4186d22033e697932f0f51f487/justoverclock-steam-api.yml',
 	],


### PR DESCRIPTION
## [`justoverclock/stats` at Packagist](https://packagist.org/packages/justoverclock/stats)

![License](https://img.shields.io/packagist/l/justoverclock/stats)

![Latest Stable Version](https://img.shields.io/packagist/v/justoverclock/stats?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/justoverclock/stats?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/justoverclock/stats) ![Monthly Downloads](https://img.shields.io/packagist/dm/justoverclock/stats) ![Daily Downloads](https://img.shields.io/packagist/dd/justoverclock/stats)](https://packagist.org/packages/justoverclock/stats/stats)

## [`justoverclockl/stats` at GitHub](https://github.com/justoverclockl/stats)

![GitHub license](https://img.shields.io/github/license/justoverclockl/stats)

[![GitHub last tag](https://img.shields.io/github/tag-date/justoverclockl/stats)](https://github.com/justoverclockl/stats/releases) [![GitHub contributors](https://img.shields.io/github/contributors/justoverclockl/stats)](https://github.com/justoverclockl/stats/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/justoverclockl/stats)](https://github.com/justoverclockl/stats/stargazers) [![GitHub forks](https://img.shields.io/github/forks/justoverclockl/stats)](https://github.com/justoverclockl/stats/network) [![GitHub issues](https://img.shields.io/github/issues/justoverclockl/stats)](https://github.com/justoverclockl/stats/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/justoverclockl/stats)](https://github.com/justoverclockl/stats/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/justoverclockl/stats)](https://github.com/justoverclockl/stats/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/justoverclockl/stats)](https://github.com/justoverclockl/stats/graphs/contributors)

## Other

https://flarum.org/extension/justoverclock/stats
