### PR TITLE
[2.x] Add `ekumanov/flarum-ext-markdown-tables`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -77,6 +77,9 @@ return [
 	'ekumanov-inline-audio' => [
 		'tag' => 'https://raw.githubusercontent.com/ekumanov/flarum-ext-inline-audio/v2.8.0/locale/en.yml',
 	],
+	'ekumanov-markdown-tables' => [
+		'tag' => 'https://raw.githubusercontent.com/ekumanov/flarum-ext-markdown-tables/v1.0.0/locale/en.yml',
+	],
 	'ekumanov-new-posts-notice' => [
 		'tag' => 'https://raw.githubusercontent.com/ekumanov/flarum-ext-new-posts-notice/v2.2.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`ekumanov/flarum-ext-markdown-tables` at Packagist](https://packagist.org/packages/ekumanov/flarum-ext-markdown-tables)

![License](https://img.shields.io/packagist/l/ekumanov/flarum-ext-markdown-tables)

![Latest Stable Version](https://img.shields.io/packagist/v/ekumanov/flarum-ext-markdown-tables?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ekumanov/flarum-ext-markdown-tables?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ekumanov/flarum-ext-markdown-tables) ![Monthly Downloads](https://img.shields.io/packagist/dm/ekumanov/flarum-ext-markdown-tables) ![Daily Downloads](https://img.shields.io/packagist/dd/ekumanov/flarum-ext-markdown-tables)](https://packagist.org/packages/ekumanov/flarum-ext-markdown-tables/stats)

## [`ekumanov/flarum-ext-markdown-tables` at GitHub](https://github.com/ekumanov/flarum-ext-markdown-tables)

![GitHub license](https://img.shields.io/github/license/ekumanov/flarum-ext-markdown-tables)

[![GitHub last tag](https://img.shields.io/github/tag-date/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/network) [![GitHub issues](https://img.shields.io/github/issues/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ekumanov/flarum-ext-markdown-tables)](https://github.com/ekumanov/flarum-ext-markdown-tables/graphs/contributors)

## Other

https://flarum.org/extension/ekumanov/flarum-ext-markdown-tables
https://discuss.flarum.org/d/39178-markdown-tables-for-flarum-20