### PR TITLE
[2.x] Add `glowingblue/password-strength`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -479,6 +479,9 @@ return [
 			'zh_Hans',
 		],
 	],
+	'glowingblue-password-strength' => [
+		'beta' => 'https://raw.githubusercontent.com/glowingblue/flarum-ext-password-strength/5.0.0-beta.2/locale/en.yml',
+	],
 	'huoxin-relative-url' => [
 		'beta' => 'https://raw.githubusercontent.com/huoxin233/flarum-ext-relative-url/2.0.0-beta.1/locale/en.yml',
 	],


### PR DESCRIPTION
## [`glowingblue/password-strength` at Packagist](https://packagist.org/packages/glowingblue/password-strength)

![License](https://img.shields.io/packagist/l/glowingblue/password-strength)

![Latest Stable Version](https://img.shields.io/packagist/v/glowingblue/password-strength?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/glowingblue/password-strength?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/glowingblue/password-strength) ![Monthly Downloads](https://img.shields.io/packagist/dm/glowingblue/password-strength) ![Daily Downloads](https://img.shields.io/packagist/dd/glowingblue/password-strength)](https://packagist.org/packages/glowingblue/password-strength/stats)

## [`glowingblue/flarum-ext-password-strength` at GitHub](https://github.com/glowingblue/flarum-ext-password-strength)

![GitHub license](https://img.shields.io/github/license/glowingblue/flarum-ext-password-strength)

[![GitHub last tag](https://img.shields.io/github/tag-date/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/releases) [![GitHub contributors](https://img.shields.io/github/contributors/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/stargazers) [![GitHub forks](https://img.shields.io/github/forks/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/network) [![GitHub issues](https://img.shields.io/github/issues/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/glowingblue/flarum-ext-password-strength)](https://github.com/glowingblue/flarum-ext-password-strength/graphs/contributors)

## Other

https://flarum.org/extension/glowingblue/password-strength
https://discuss.flarum.org/d/26191-gb-password-strength