### PR TITLE
[1.x] Exclude `ffans/creator-declarations` for Chinese (Simplified)

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -492,6 +492,9 @@ return [
 	],
 	'ffans-creator-declarations' => [
 		'tag' => 'https://raw.githubusercontent.com/FFans/creator-declarations/v0.1.0/locale/en.yml',
+		'__builtInLanguages' => [
+			'zh_Hans',
+		],
 	],
 	'ffans-geetest' => [
 		'tag' => 'https://raw.githubusercontent.com/FFans/geetest/v1.1.0/resources/locale/en.yml',


### PR DESCRIPTION
remove translation for Simplified Chinese

TODO
- [x] ~remove yml file in `flarum-lang/chinese-simplified`~ NO NEED