### PR TITLE
[2.x] Exclude `ffans/creator-declarations` for Chinese (Simplified)

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -192,7 +192,10 @@ return [
 		'tag' => 'https://raw.githubusercontent.com/ernestdefoe/typesense/v0.2.1/locale/en.yml',
 	],
 	'ffans-creator-declarations' => [
-		'tag' => 'https://raw.githubusercontent.com/FFans/creator-declarations/v0.2.2/locale/en.yml',
+		'tag' => 'https://raw.githubusercontent.com/FFans/creator-declarations/v0.2.3/locale/en.yml',
+		'__builtInLanguages' => [
+			'zh_Hans',
+		],
 	],
 	'flarum-akismet' => [
 		'beta' => 'https://raw.githubusercontent.com/flarum/akismet/v2.0.0-rc.8/locale/en.yml',


### PR DESCRIPTION
exclude Simplified Chinese, it is bundled within the package itself

https://github.com/flarum-lang/chinese-simplified/pull/35 will be merge after this PR.