### PR TITLE
[2.x] Add `jslirola/flarum-ext-login2seeplus`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -674,6 +674,12 @@ return [
 	'irmmr-rtl' => [
 		'tag' => 'https://raw.githubusercontent.com/irmmr/flarum-ext-rtl/v1.0.2/locale/en.yml',
 	],
+	'jslirola-login2seeplus' => [
+		'beta' => 'https://raw.githubusercontent.com/jslirola/flarum-ext-login2seeplus/v2.0.0-beta.2/locale/en.yml',
+		'__builtInLanguages' => [
+			'es',
+		],
+	],
 	'justoverclock-related-discussions' => [
 		'tag' => 'https://raw.githubusercontent.com/flarum-com/premium-translations/main/justoverclock-related-discussions.yml',
 	],


### PR DESCRIPTION
## [`jslirola/flarum-ext-login2seeplus` at Packagist](https://packagist.org/packages/jslirola/flarum-ext-login2seeplus)

![License](https://img.shields.io/packagist/l/jslirola/flarum-ext-login2seeplus)

![Latest Stable Version](https://img.shields.io/packagist/v/jslirola/flarum-ext-login2seeplus?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/jslirola/flarum-ext-login2seeplus?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/jslirola/flarum-ext-login2seeplus) ![Monthly Downloads](https://img.shields.io/packagist/dm/jslirola/flarum-ext-login2seeplus) ![Daily Downloads](https://img.shields.io/packagist/dd/jslirola/flarum-ext-login2seeplus)](https://packagist.org/packages/jslirola/flarum-ext-login2seeplus/stats)

## [`jslirola/flarum-ext-login2seeplus` at GitHub](https://github.com/jslirola/flarum-ext-login2seeplus)

![GitHub license](https://img.shields.io/github/license/jslirola/flarum-ext-login2seeplus)

[![GitHub last tag](https://img.shields.io/github/tag-date/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/releases) [![GitHub contributors](https://img.shields.io/github/contributors/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/stargazers) [![GitHub forks](https://img.shields.io/github/forks/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/network) [![GitHub issues](https://img.shields.io/github/issues/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/jslirola/flarum-ext-login2seeplus)](https://github.com/jslirola/flarum-ext-login2seeplus/graphs/contributors)

## Other

https://flarum.org/extension/jslirola/flarum-ext-login2seeplus
https://discuss.flarum.org/d/24193-login-2-see-plus