### PR TITLE
[2.x] Add `ernestdefoe/ridge`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -200,6 +200,9 @@ return [
 	'ernestdefoe-respawn' => [
 		'tag' => 'https://raw.githubusercontent.com/ernestdefoe/respawn/3.0.3/locale/en.yml',
 	],
+	'ernestdefoe-ridge' => [
+		'tag' => 'https://raw.githubusercontent.com/ernestdefoe/ridge/v1.0.0/locale/en.yml',
+	],
 	'ernestdefoe-roleplay' => [
 		'tag' => 'https://raw.githubusercontent.com/ernestdefoe/roleplay/v1.1.1/resources/locale/en.yml',
 	],


### PR DESCRIPTION
## [`ernestdefoe/ridge` at Packagist](https://packagist.org/packages/ernestdefoe/ridge)

![License](https://img.shields.io/packagist/l/ernestdefoe/ridge)

![Latest Stable Version](https://img.shields.io/packagist/v/ernestdefoe/ridge?color=success&label=stable) ![Latest Unstable Version](https://img.shields.io/packagist/v/ernestdefoe/ridge?include_prereleases&label=unstable)
[![Total Downloads](https://img.shields.io/packagist/dt/ernestdefoe/ridge) ![Monthly Downloads](https://img.shields.io/packagist/dm/ernestdefoe/ridge) ![Daily Downloads](https://img.shields.io/packagist/dd/ernestdefoe/ridge)](https://packagist.org/packages/ernestdefoe/ridge/stats)

## [`ernestdefoe/ridge` at GitHub](https://github.com/ernestdefoe/ridge)

![GitHub license](https://img.shields.io/github/license/ernestdefoe/ridge)

[![GitHub last tag](https://img.shields.io/github/tag-date/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/releases) [![GitHub contributors](https://img.shields.io/github/contributors/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/graphs/contributors)
[![GitHub stars](https://img.shields.io/github/stars/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/stargazers) [![GitHub forks](https://img.shields.io/github/forks/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/network) [![GitHub issues](https://img.shields.io/github/issues/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/issues)

[![GitHub last commit](https://img.shields.io/github/last-commit/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/commits) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/ernestdefoe/ridge)](https://github.com/ernestdefoe/ridge/graphs/contributors)

## Other

https://flarum.org/extension/ernestdefoe/ridge
https://discuss.flarum.org/d/39849-ridge-a-long-thread-shows-its-own-high-ground-built-using-ai